### PR TITLE
Add GraphML snapshot exporter

### DIFF
--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/GraphSnapshotService.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/GraphSnapshotService.java
@@ -1,0 +1,68 @@
+package com.example.mapper.service;
+
+import com.example.mapper.model.DependencyClaim;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class GraphSnapshotService {
+    private final DependencyResolver resolver;
+    private final Path snapshotDir;
+
+    public GraphSnapshotService(DependencyResolver resolver,
+                                @Value("${snapshot.dir:snapshots}") String dir) throws IOException {
+        this.resolver = resolver;
+        this.snapshotDir = Path.of(dir);
+        Files.createDirectories(snapshotDir);
+    }
+
+    public Path exportSnapshot() throws IOException {
+        Map<String, Map<String, DependencyClaim>> graph = resolver.resolve();
+        Set<String> nodes = graph.keySet();
+        nodes.addAll(graph.values().stream()
+                .flatMap(m -> m.keySet().stream())
+                .collect(Collectors.toSet()));
+
+        String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+        Path file = snapshotDir.resolve("dependencies-" + timestamp + ".graphml");
+
+        try (FileWriter writer = new FileWriter(file.toFile())) {
+            writer.write("<graphml>\n");
+            writer.write("  <graph edgedefault=\"directed\">\n");
+            for (String node : nodes) {
+                writer.write("    <node id=\"" + node + "\"/>\n");
+            }
+            for (var fromEntry : graph.entrySet()) {
+                String from = fromEntry.getKey();
+                for (var toEntry : fromEntry.getValue().entrySet()) {
+                    String to = toEntry.getKey();
+                    writer.write("    <edge source=\"" + from + "\" target=\"" + to + "\"/>\n");
+                }
+            }
+            writer.write("  </graph>\n</graphml>\n");
+        }
+
+        cleanupOldSnapshots();
+        return file;
+    }
+
+    private void cleanupOldSnapshots() throws IOException {
+        var files = Files.list(snapshotDir)
+                .filter(p -> p.getFileName().toString().endsWith(".graphml"))
+                .sorted((a, b) -> b.getFileName().toString().compareTo(a.getFileName().toString()))
+                .collect(Collectors.toList());
+        for (int i = 3; i < files.size(); i++) {
+            Files.deleteIfExists(files.get(i));
+        }
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/web/DependencyController.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/web/DependencyController.java
@@ -1,22 +1,32 @@
 package com.example.mapper.web;
 
 import com.example.mapper.service.DependencyResolver;
+import com.example.mapper.service.GraphSnapshotService;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/dependencies")
 public class DependencyController {
     private final DependencyResolver resolver;
+    private final GraphSnapshotService snapshotService;
 
-    public DependencyController(DependencyResolver resolver) {
+    public DependencyController(DependencyResolver resolver, GraphSnapshotService snapshotService) {
         this.resolver = resolver;
+        this.snapshotService = snapshotService;
     }
 
     @GetMapping
     public List<String> list() {
         return resolver.toList();
+    }
+
+    @GetMapping("/export")
+    public Path export() throws IOException {
+        return snapshotService.exportSnapshot();
     }
 }

--- a/dependency-mapper/dependency-mapper/src/main/resources/application.properties
+++ b/dependency-mapper/dependency-mapper/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.username=sa
 spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=update
+snapshot.dir=snapshots

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/GraphSnapshotServiceTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/GraphSnapshotServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.mapper;
+
+import com.example.mapper.service.GraphSnapshotService;
+import com.example.mapper.service.LogIngestionService;
+import com.example.mapper.service.DependencyResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GraphSnapshotServiceTest {
+
+    @Autowired
+    private LogIngestionService ingestionService;
+
+    @Autowired
+    private GraphSnapshotService snapshotService;
+
+    @Autowired
+    private DependencyResolver resolver;
+
+    @Test
+    void testExportSnapshot() throws IOException {
+        Path temp = Files.createTempFile("log", ".txt");
+        try (FileWriter w = new FileWriter(temp.toFile())) {
+            w.write("ServiceA->ServiceB\n");
+        }
+        ingestionService.ingestLog(temp.toString(), "test", 1.0);
+        Path file = snapshotService.exportSnapshot();
+        assertTrue(Files.exists(file));
+        // call again to ensure retention logic (should keep at most 3)
+        snapshotService.exportSnapshot();
+        snapshotService.exportSnapshot();
+        snapshotService.exportSnapshot();
+        long count = Files.list(file.getParent()).filter(p -> p.toString().endsWith(".graphml")).count();
+        assertTrue(count <= 3);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GraphSnapshotService` to write resolved graphs as GraphML
- expose `/api/dependencies/export` endpoint for manual snapshot creation
- keep only the three most recent snapshots
- configure snapshot directory via `snapshot.dir`
- add unit test `GraphSnapshotServiceTest`

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867239decf083228d4d7e0886c08722