### PR TITLE
Add release log automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AwesomeProject
+
+This repository contains a React Native project built with Expo.
+
+## Release Logging
+
+A release log is maintained in `RELEASE_LOG.md`. After each commit you can run the following commands to update the release log and append the latest commit information to this README:
+
+```bash
+npm run generate-release-log
+npm run update-readme
+```
+
+These scripts capture commit metadata such as hash, author, date, and message. Each entry is appended to the release log and to the README so that commit history is tracked directly in the repository documentation.
+
+### Fri Jul 4 09:51:11 2025 +0300
+- Merge pull request #2 from amolchavan777/codex/assess-progress-on-application-dependency-mapping-system (873129f27e6474a7fb0e33983311026b5d38dfda)

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -1,0 +1,25 @@
+commit 5b7985a73de5d30d3fdb859abc044ed433f88057
+Author: Amol Chavan
+Date:   Tue Dec 18 19:27:13 2018 +0530
+Message: First checkin of the reactJS app on Expo
+
+commit 6172fd90bed5190df12fbe6ea32f4491ed62f8d1
+Author: Amol Chavan
+Date:   Fri Jul 4 03:36:20 2025 +0300
+Message: Add Java-based dependency mapper prototype
+
+commit 248d5a09aa033df0e6f64f720ff65fb63eb5c22c
+Author: Amol Chavan
+Date:   Fri Jul 4 03:37:19 2025 +0300
+Message: Merge pull request #1 from amolchavan777/codex/create-working-prototype-for-dependency-mapping-system
+
+commit 8b3ed8fd053b9df9a55a50cf97adbae388972064
+Author: Amol Chavan
+Date:   Fri Jul 4 09:50:05 2025 +0300
+Message: Add GraphML snapshot export
+
+commit 873129f27e6474a7fb0e33983311026b5d38dfda
+Author: Amol Chavan
+Date:   Fri Jul 4 09:51:11 2025 +0300
+Message: Merge pull request #2 from amolchavan777/codex/assess-progress-on-application-dependency-mapping-system
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "eject": "expo eject",
-    "test": "node ./node_modules/jest/bin/jest.js --watchAll"
+    "test": "node ./node_modules/jest/bin/jest.js --watchAll",
+    "generate-release-log": "node scripts/generateReleaseLog.js",
+    "update-readme": "node scripts/updateReadme.js"
   },
   "jest": {
     "preset": "jest-expo"

--- a/scripts/generateReleaseLog.js
+++ b/scripts/generateReleaseLog.js
@@ -1,0 +1,29 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const logFile = path.join(__dirname, '..', 'RELEASE_LOG.md');
+let lastCommit = '';
+if (fs.existsSync(logFile)) {
+  const content = fs.readFileSync(logFile, 'utf8');
+  const match = content.trim().split('\n').reverse().find(line => line.startsWith('commit '));
+  if (match) {
+    lastCommit = match.split(' ')[1];
+  }
+}
+
+let cmd = 'git log --pretty=format:"%H||%an||%ad||%s"';
+if (lastCommit) {
+  cmd += ` ${lastCommit}..HEAD`;
+}
+const logs = execSync(cmd, { encoding: 'utf8' }).trim();
+if (!logs) process.exit(0);
+
+const entries = logs.split('\n').reverse();
+let output = '';
+entries.forEach(line => {
+  const [hash, author, date, msg] = line.split('||');
+  output += `commit ${hash}\nAuthor: ${author}\nDate:   ${date}\nMessage: ${msg}\n\n`;
+});
+
+fs.appendFileSync(logFile, output);

--- a/scripts/updateReadme.js
+++ b/scripts/updateReadme.js
@@ -1,0 +1,15 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const readmeFile = path.join(__dirname, '..', 'README.md');
+let readme = '';
+if (fs.existsSync(readmeFile)) {
+  readme = fs.readFileSync(readmeFile, 'utf8');
+}
+
+const log = execSync('git log -1 --pretty=format:"%H||%ad||%s"').toString().trim();
+const [hash, date, msg] = log.split('||');
+
+const entry = `\n### ${date}\n- ${msg} (${hash})\n`;
+fs.writeFileSync(readmeFile, readme + entry);


### PR DESCRIPTION
## Summary
- introduce scripts to generate release log entries and append commit details to README
- initialize README and RELEASE_LOG
- document commands in `package.json`

## Testing
- `node scripts/generateReleaseLog.js`
- `node scripts/updateReadme.js`
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68677d10e19883228c2b4870c9fcee52