### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# AwesomeProject
+
+This project is a React Native application managed by Expo.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (v10 or later recommended)
+- [Yarn](https://yarnpkg.com/) or npm
+- Expo CLI (`npm install -g expo-cli`)
+
+## Install dependencies
+
+From the repository root, run:
+
+```bash
+npm install
+```
+
+## Running the project
+
+Start the development server with:
+
+```bash
+npm start
+```
+
+This will launch Expo in development mode. You can then:
+
+- Press **`a`** to open the Android emulator (if available)
+- Press **`i`** to open the iOS simulator (macOS only)
+- Scan the QR code with the Expo Go app on your device
+
+## Running tests
+
+To execute the test suite, run:
+
+```bash
+npm test
+```
+
+Tests are based on Jest and React Native Testing Library.


### PR DESCRIPTION
## Summary
- add README with instructions to install dependencies, run the app, and run tests

## Testing
- `npx jest` *(fails: cannot parse module)*

------
https://chatgpt.com/codex/tasks/task_e_68677d58065c8322a64b549a04967e13