### PR TITLE
Implement Bayesian conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ npm test
 
 Tests are based on Jest and React Native Testing Library.
 
+## Dependency Mapper Prototype
+
+The `dependency-mapper` directory contains a Spring Boot prototype implementing
+automated dependency mapping. The `DependencyResolver` now uses a simplified
+Bayesian approach to choose the most trustworthy dependency claims when multiple
+sources provide conflicting information.
+
 This repository contains a React Native project built with Expo.
 
 ## Release Logging
@@ -57,3 +64,9 @@ These scripts capture commit metadata such as hash, author, date, and message. E
 ### Fri Jul 4 09:51:11 2025 +0300
 - Merge pull request #2 from amolchavan777/codex/assess-progress-on-application-dependency-mapping-system (873129f27e6474a7fb0e33983311026b5d38dfda)
 
+
+### Fri Jul 4 13:49:40 2025 +0300
+- some basic stuff (a17b175c2a897a789447b700da0cd63e5d8ef52f)
+
+### Fri Jul 4 13:15:37 2025 +0000
+- Implement Bayesian conflict resolution (0cadcf89c3851787b7242d31719e2fed57139d1a)

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -23,3 +23,38 @@ Author: Amol Chavan
 Date:   Fri Jul 4 09:51:11 2025 +0300
 Message: Merge pull request #2 from amolchavan777/codex/assess-progress-on-application-dependency-mapping-system
 
+commit d31b90e3a3cfee3e58faea816fefb323d59de083
+Author: Amol Chavan
+Date:   Fri Jul 4 10:06:50 2025 +0300
+Message: Add release log utilities
+
+commit 6c13c7356232618d361b9a109c9638bbfb0ee944
+Author: Amol Chavan
+Date:   Fri Jul 4 10:08:27 2025 +0300
+Message: Merge pull request #3 from amolchavan777/codex/add-release-log-generation-for-commits
+
+commit b7f108b9ff3c0405c5424669c390db483ad785b4
+Author: Amol Chavan
+Date:   Fri Jul 4 10:10:50 2025 +0300
+Message: Add README with basic setup instructions
+
+commit 2ea9655c0b2a35710d64ea26989ce0acd9103c5e
+Author: Amol Chavan
+Date:   Fri Jul 4 10:11:47 2025 +0300
+Message: Merge branch 'master' into codex/add-instructions-to-run-project-in-readme
+
+commit 2c530e478f037e5233ba17d0810f6176013ae006
+Author: Amol Chavan
+Date:   Fri Jul 4 10:11:55 2025 +0300
+Message: Merge pull request #4 from amolchavan777/codex/add-instructions-to-run-project-in-readme
+
+commit a17b175c2a897a789447b700da0cd63e5d8ef52f
+Author: Amol Chavan
+Date:   Fri Jul 4 13:49:40 2025 +0300
+Message: some basic stuff
+
+commit 0cadcf89c3851787b7242d31719e2fed57139d1a
+Author: Codex
+Date:   Fri Jul 4 13:15:37 2025 +0000
+Message: Implement Bayesian conflict resolution
+


### PR DESCRIPTION
## Summary
- implement simple Bayesian credibility in `DependencyResolver`
- describe the Dependency Mapper prototype in README
- update release logs

## Testing
- `npm test` *(fails: require.requireActual is not a function)*
- `mvn -f dependency-mapper/dependency-mapper/pom.xml -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867d11b160c8322bb9b35331296cda4