### PR TITLE
Implement weighted conflict resolver with timestamps

### DIFF
--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/model/DependencyClaim.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/model/DependencyClaim.java
@@ -5,6 +5,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import java.time.Instant;
 import lombok.Data;
 
 @Data
@@ -19,4 +20,5 @@ public class DependencyClaim {
     private ApplicationService toService;
     private String source;
     private double confidence;
+    private Instant timestamp;
 }

--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/LogIngestionService.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/LogIngestionService.java
@@ -7,6 +7,7 @@ import com.example.mapper.repo.DependencyClaimRepository;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.time.Instant;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +49,7 @@ public class LogIngestionService {
                 claim.setToService(toSvc);
                 claim.setSource(source);
                 claim.setConfidence(confidence);
+                claim.setTimestamp(Instant.now());
                 claimRepo.save(claim);
             }
         }

--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/WeightedConflictResolver.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/WeightedConflictResolver.java
@@ -1,0 +1,86 @@
+package com.example.mapper.service;
+
+import com.example.mapper.model.DependencyClaim;
+import com.example.mapper.repo.DependencyClaimRepository;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WeightedConflictResolver {
+    private final DependencyClaimRepository claimRepo;
+    private final Map<String, Double> priorities;
+    private final Map<String, String> overrides;
+
+    public WeightedConflictResolver(DependencyClaimRepository claimRepo,
+                                    @Value("#{${source.priorities:{}}}") Map<String, Double> priorities,
+                                    @Value("#{${overrides:{}}}") Map<String, String> overrides) {
+        this.claimRepo = claimRepo;
+        this.priorities = priorities;
+        this.overrides = overrides;
+    }
+
+    private double score(DependencyClaim claim, int frequency) {
+        double priority = priorities.getOrDefault(claim.getSource(), 1.0);
+        double recency = 0.0;
+        Instant ts = claim.getTimestamp();
+        if (ts != null) {
+            recency = ts.toEpochMilli() / 1_000_000_000.0;
+        }
+        return claim.getConfidence() * priority + frequency + recency;
+    }
+
+    public Map<String, Map<String, DependencyClaim>> resolve() {
+        List<DependencyClaim> claims = claimRepo.findAll();
+        Map<String, Map<String, List<DependencyClaim>>> grouped = claims.stream()
+                .collect(Collectors.groupingBy(
+                        c -> c.getFromService().getName(),
+                        Collectors.groupingBy(c -> c.getToService().getName())));
+
+        Map<String, Map<String, DependencyClaim>> result = new HashMap<>();
+
+        for (var fromEntry : grouped.entrySet()) {
+            String from = fromEntry.getKey();
+            result.putIfAbsent(from, new HashMap<>());
+            for (var toEntry : fromEntry.getValue().entrySet()) {
+                String to = toEntry.getKey();
+                List<DependencyClaim> options = toEntry.getValue();
+                int freq = options.size();
+                DependencyClaim best = options.get(0);
+                double bestScore = score(best, freq);
+                for (DependencyClaim c : options) {
+                    double s = score(c, freq);
+                    if (s > bestScore) {
+                        bestScore = s;
+                        best = c;
+                    }
+                }
+
+                String override = overrides.get(from + "->" + to);
+                if (override != null) {
+                    for (DependencyClaim c : options) {
+                        if (c.getSource().equals(override)) {
+                            best = c;
+                            break;
+                        }
+                    }
+                }
+
+                result.get(from).put(to, best);
+            }
+        }
+
+        return result;
+    }
+
+    public List<String> toList() {
+        return resolve().entrySet().stream()
+                .flatMap(e -> e.getValue().values().stream())
+                .map(c -> c.getFromService().getName() + "->" + c.getToService().getName())
+                .collect(Collectors.toList());
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/main/resources/application.properties
+++ b/dependency-mapper/dependency-mapper/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=update
 snapshot.dir=snapshots
+source.priorities.manual=10
+source.priorities.auto=1

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/WeightedConflictResolverTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/WeightedConflictResolverTest.java
@@ -1,0 +1,81 @@
+package com.example.mapper;
+
+import com.example.mapper.model.ApplicationService;
+import com.example.mapper.model.DependencyClaim;
+import com.example.mapper.repo.ApplicationServiceRepository;
+import com.example.mapper.repo.DependencyClaimRepository;
+import com.example.mapper.service.WeightedConflictResolver;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "source.priorities.manual=5",
+        "source.priorities.auto=1",
+        "overrides.ServiceA->ServiceC=manual"
+})
+public class WeightedConflictResolverTest {
+
+    @Autowired
+    private ApplicationServiceRepository serviceRepo;
+
+    @Autowired
+    private DependencyClaimRepository claimRepo;
+
+    @Autowired
+    private WeightedConflictResolver resolver;
+
+    @Test
+    void testConflictResolution() {
+        ApplicationService a = new ApplicationService();
+        a.setName("ServiceA");
+        a = serviceRepo.save(a);
+        ApplicationService b = new ApplicationService();
+        b.setName("ServiceB");
+        b = serviceRepo.save(b);
+        ApplicationService c = new ApplicationService();
+        c.setName("ServiceC");
+        c = serviceRepo.save(c);
+
+        DependencyClaim oldClaim = new DependencyClaim();
+        oldClaim.setFromService(a);
+        oldClaim.setToService(c);
+        oldClaim.setSource("auto");
+        oldClaim.setConfidence(0.9);
+        oldClaim.setTimestamp(Instant.now().minusSeconds(3600));
+        claimRepo.save(oldClaim);
+
+        DependencyClaim newClaim = new DependencyClaim();
+        newClaim.setFromService(a);
+        newClaim.setToService(c);
+        newClaim.setSource("manual");
+        newClaim.setConfidence(0.6);
+        newClaim.setTimestamp(Instant.now());
+        claimRepo.save(newClaim);
+
+        DependencyClaim freqClaim1 = new DependencyClaim();
+        freqClaim1.setFromService(a);
+        freqClaim1.setToService(b);
+        freqClaim1.setSource("auto");
+        freqClaim1.setConfidence(0.7);
+        freqClaim1.setTimestamp(Instant.now());
+        claimRepo.save(freqClaim1);
+
+        DependencyClaim freqClaim2 = new DependencyClaim();
+        freqClaim2.setFromService(a);
+        freqClaim2.setToService(b);
+        freqClaim2.setSource("auto");
+        freqClaim2.setConfidence(0.7);
+        freqClaim2.setTimestamp(Instant.now());
+        claimRepo.save(freqClaim2);
+
+        var resolved = resolver.resolve();
+        assertEquals(newClaim.getId(), resolved.get("ServiceA").get("ServiceC").getId(), "manual override should win");
+        assertEquals(freqClaim1.getId(), resolved.get("ServiceA").get("ServiceB").getId(), "frequency should keep auto claim");
+    }
+}


### PR DESCRIPTION
## Summary
- track when each `DependencyClaim` was created via a new `timestamp` field
- apply timestamps when ingesting logs
- add `WeightedConflictResolver` service for priority, recency, frequency, and overrides
- expose example priorities in properties
- test conflict resolution logic

## Testing
- `mvn -q test` *(fails: could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68682b9644888322a394306e12ae6caf