### PR TITLE
Implement adapter pattern framework

### DIFF
--- a/service/adapter/AdapterFactory.js
+++ b/service/adapter/AdapterFactory.js
@@ -1,0 +1,13 @@
+const adapters = {};
+
+function registerAdapter(name, adapterClass) {
+  adapters[name] = adapterClass;
+}
+
+function createAdapter(name, options) {
+  const Adapter = adapters[name];
+  if (!Adapter) throw new Error(`Adapter ${name} not registered`);
+  return new Adapter(options);
+}
+
+module.exports = { registerAdapter, createAdapter };

--- a/service/adapter/ApiGatewayAdapter.js
+++ b/service/adapter/ApiGatewayAdapter.js
@@ -1,0 +1,19 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+const fetch = require('node-fetch');
+
+class ApiGatewayAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super();
+    this.endpoint = options.endpoint || '';
+  }
+
+  async fetch() {
+    if (!this.endpoint) return null;
+    const res = await fetch(this.endpoint).catch(() => null);
+    if (!res || !res.ok) return null;
+    const data = await res.json();
+    return data;
+  }
+}
+
+module.exports = ApiGatewayAdapter;

--- a/service/adapter/CICDAdapter.js
+++ b/service/adapter/CICDAdapter.js
@@ -1,0 +1,20 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+
+class CICDAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super();
+    this.env = options.env || process.env;
+  }
+
+  fetch() {
+    // Return minimal CI/CD related environment variables
+    const keys = ['CI', 'GITHUB_ACTIONS', 'TRAVIS'];
+    const data = {};
+    keys.forEach(k => {
+      if (this.env[k]) data[k] = this.env[k];
+    });
+    return data;
+  }
+}
+
+module.exports = CICDAdapter;

--- a/service/adapter/CodebaseAdapter.js
+++ b/service/adapter/CodebaseAdapter.js
@@ -1,0 +1,17 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+const fs = require('fs');
+
+class CodebaseAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super();
+    this.path = options.path || process.cwd();
+  }
+
+  fetch() {
+    if (!fs.existsSync(this.path)) return null;
+    const files = fs.readdirSync(this.path);
+    return files;
+  }
+}
+
+module.exports = CodebaseAdapter;

--- a/service/adapter/DataSourceAdapter.js
+++ b/service/adapter/DataSourceAdapter.js
@@ -1,0 +1,20 @@
+class DataSourceAdapter {
+  constructor(builder) {
+    this.builder = builder;
+  }
+
+  // Fetch raw data from the source. Subclasses should override.
+  fetch(_input) {
+    throw new Error('fetch() must be implemented by subclass');
+  }
+
+  // Parse raw data using a builder when provided
+  parse(raw) {
+    if (this.builder && typeof this.builder.parse === 'function') {
+      return this.builder.parse(raw).build();
+    }
+    return raw;
+  }
+}
+
+module.exports = DataSourceAdapter;

--- a/service/adapter/NetworkLogAdapter.js
+++ b/service/adapter/NetworkLogAdapter.js
@@ -1,0 +1,19 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+const fs = require('fs');
+
+class NetworkLogAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super();
+    this.logFile = options.logFile || '';
+  }
+
+  fetch() {
+    if (!this.logFile || !fs.existsSync(this.logFile)) {
+      return null;
+    }
+    const raw = fs.readFileSync(this.logFile, 'utf8');
+    return this.parse(raw);
+  }
+}
+
+module.exports = NetworkLogAdapter;

--- a/service/adapter/RouterLogAdapter.js
+++ b/service/adapter/RouterLogAdapter.js
@@ -1,0 +1,20 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+const RouterLogBuilder = require('./builders/RouterLogBuilder');
+const fs = require('fs');
+
+class RouterLogAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super(new RouterLogBuilder());
+    this.logFile = options.logFile || '';
+  }
+
+  fetch() {
+    if (!this.logFile || !fs.existsSync(this.logFile)) {
+      return null;
+    }
+    const raw = fs.readFileSync(this.logFile, 'utf8');
+    return this.parse(raw);
+  }
+}
+
+module.exports = RouterLogAdapter;

--- a/service/adapter/TelemetryAdapter.js
+++ b/service/adapter/TelemetryAdapter.js
@@ -1,0 +1,15 @@
+const DataSourceAdapter = require('./DataSourceAdapter');
+
+class TelemetryAdapter extends DataSourceAdapter {
+  constructor(options = {}) {
+    super();
+    this.metrics = options.metrics || [];
+  }
+
+  fetch() {
+    // Return provided metrics; in real world this would query telemetry system
+    return this.metrics;
+  }
+}
+
+module.exports = TelemetryAdapter;

--- a/service/adapter/builders/RouterLogBuilder.js
+++ b/service/adapter/builders/RouterLogBuilder.js
@@ -1,0 +1,33 @@
+class RouterLogBuilder {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this.log = {};
+    this.raw = '';
+  }
+
+  withRaw(raw) {
+    this.raw = raw;
+    return this;
+  }
+
+  // Example parse implementation
+  parse(raw) {
+    this.withRaw(raw);
+    const parts = String(this.raw).trim().split('|');
+    this.log.timestamp = parts[0] || null;
+    this.log.level = parts[1] || null;
+    this.log.message = parts.slice(2).join('|') || null;
+    return this;
+  }
+
+  build() {
+    const result = this.log;
+    this.reset();
+    return result;
+  }
+}
+
+module.exports = RouterLogBuilder;

--- a/service/adapter/index.js
+++ b/service/adapter/index.js
@@ -1,0 +1,26 @@
+const { registerAdapter, createAdapter } = require('./AdapterFactory');
+const RouterLogAdapter = require('./RouterLogAdapter');
+const CodebaseAdapter = require('./CodebaseAdapter');
+const CICDAdapter = require('./CICDAdapter');
+const ApiGatewayAdapter = require('./ApiGatewayAdapter');
+const TelemetryAdapter = require('./TelemetryAdapter');
+const NetworkLogAdapter = require('./NetworkLogAdapter');
+
+// register built-in adapters
+registerAdapter('routerLog', RouterLogAdapter);
+registerAdapter('codebase', CodebaseAdapter);
+registerAdapter('cicd', CICDAdapter);
+registerAdapter('apiGateway', ApiGatewayAdapter);
+registerAdapter('telemetry', TelemetryAdapter);
+registerAdapter('networkLog', NetworkLogAdapter);
+
+module.exports = {
+  registerAdapter,
+  createAdapter,
+  RouterLogAdapter,
+  CodebaseAdapter,
+  CICDAdapter,
+  ApiGatewayAdapter,
+  TelemetryAdapter,
+  NetworkLogAdapter,
+};


### PR DESCRIPTION
## Summary
- add new `service/adapter` folder
- introduce `DataSourceAdapter` base interface
- implement router log, codebase, CICD, API gateway, telemetry and network log adapters using the Strategy pattern
- add `RouterLogBuilder` to parse router log inputs
- register adapters using a simple factory

## Testing
- `npm test -- --ci` *(fails: require.requireActual is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68682cdf52d4832280c83ed79d4bc273