### PR TITLE
Add dependency dashboard screen

### DIFF
--- a/navigation/MainTabNavigator.js
+++ b/navigation/MainTabNavigator.js
@@ -6,6 +6,7 @@ import TabBarIcon from '../components/TabBarIcon';
 import HomeScreen from '../screens/HomeScreen';
 import LinksScreen from '../screens/LinksScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import DependencyDashboard from '../screens/DependencyDashboard';
 
 const HomeStack = createStackNavigator({
   Home: HomeScreen,
@@ -37,6 +38,20 @@ LinksStack.navigationOptions = {
       name={Platform.OS === 'ios' ? 'ios-link' : 'md-link'}
     />
   ),
+}; 
+
+const DependencyStack = createStackNavigator({
+  Dependencies: DependencyDashboard,
+});
+
+DependencyStack.navigationOptions = {
+  tabBarLabel: 'Deps',
+  tabBarIcon: ({ focused }) => (
+    <TabBarIcon
+      focused={focused}
+      name={Platform.OS === 'ios' ? 'ios-analytics' : 'md-analytics'}
+    />
+  ),
 };
 
 const SettingsStack = createStackNavigator({
@@ -56,5 +71,6 @@ SettingsStack.navigationOptions = {
 export default createBottomTabNavigator({
   HomeStack,
   LinksStack,
+  DependencyStack,
   SettingsStack,
 });

--- a/screens/DependencyDashboard.js
+++ b/screens/DependencyDashboard.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Text, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+
+export default class DependencyDashboard extends React.Component {
+  static navigationOptions = {
+    title: 'Dependencies',
+  };
+
+  state = {
+    dependencies: [],
+    loading: true,
+    error: null,
+  };
+
+  componentDidMount() {
+    this._load();
+  }
+
+  _load = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/api/dependencies');
+      if (!res.ok) throw new Error('Request failed');
+      const deps = await res.json();
+      this.setState({ dependencies: deps, loading: false });
+    } catch (err) {
+      this.setState({ error: err.message, loading: false });
+    }
+  };
+
+  _renderItem = ({ item }) => (
+    <View style={styles.item}>
+      <Text>{item}</Text>
+    </View>
+  );
+
+  render() {
+    const { dependencies, loading, error } = this.state;
+    if (loading) {
+      return (
+        <View style={styles.center}>
+          <ActivityIndicator />
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View style={styles.center}>
+          <Text>Error: {error}</Text>
+        </View>
+      );
+    }
+
+    return (
+      <FlatList
+        data={dependencies}
+        keyExtractor={(item, idx) => String(idx)}
+        renderItem={this._renderItem}
+        contentContainerStyle={dependencies.length ? null : styles.center}
+        ListEmptyComponent={<Text>No dependencies</Text>}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  item: {
+    padding: 15,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+  },
+});


### PR DESCRIPTION
## Summary
- add new `DependencyDashboard` screen that loads dependencies from the Spring Boot API
- wire up the new screen in `MainTabNavigator`

## Testing
- `npm install`
- `npx jest --runInBand` *(fails: require.requireActual is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686830a2e2bc832280173300bd26e8ea