### PR TITLE
Add web support instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ This will launch Expo in development mode. You can then:
 - Press **`i`** to open the iOS simulator (macOS only)
 - Scan the QR code with the Expo Go app on your device
 
+### Running in the browser
+
+Expo supports running the project in a web browser via React Native Web. Launch
+the development server with:
+
+```bash
+npm run web
+```
+
+This executes `expo start --web` under the hood, opening the app in your
+default browser.
+
 ## Running tests
 
 To execute the test suite, run:

--- a/app.json
+++ b/app.json
@@ -6,7 +6,8 @@
     "sdkVersion": "53.0.0",
     "platforms": [
       "ios",
-      "android"
+      "android",
+      "web"
     ],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
+    "web": "expo start --web",
     "eject": "expo eject",
     "test": "node ./node_modules/jest/bin/jest.js --watchAll",
     "generate-release-log": "node scripts/generateReleaseLog.js",


### PR DESCRIPTION
## Summary
- mention how to run app in a web browser via expo
- expose `web` script in `package.json`
- add `web` to supported `platforms` in `app.json`

## Testing
- `npm test --silent` *(fails: require.requireActual is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68683754491c8322a63fd800b704b5d2