### PR TITLE
Add RouterLogAdapter

### DIFF
--- a/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/adapter/Claim.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/adapter/Claim.java
@@ -1,0 +1,15 @@
+package com.enterprise.dependency.adapter;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Represents a parsed dependency claim from a router log entry.
+ */
+@Data
+public class Claim {
+    private Instant timestamp;
+    private String sourceIp;
+    private String targetIp;
+    private double confidence;
+}

--- a/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/adapter/RouterLogAdapter.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/adapter/RouterLogAdapter.java
@@ -1,0 +1,90 @@
+package com.enterprise.dependency.adapter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Adapter that parses Apache/Nginx style access logs and converts them into
+ * {@link Claim} objects.
+ */
+public class RouterLogAdapter {
+
+    // example: 10.0.0.1 - - [01/Jan/2024:12:00:00 +0000] "GET / HTTP/1.1" 200 123 192.168.1.10:80
+    private static final Pattern LOG_PATTERN = Pattern.compile(
+        "^(\\S+) - - \\[([^\\]]+)\\] \"\\S+ \\S+ [^\"]+\" (\\d{3}) \\d+(?: (\\S+))?"
+    );
+
+    private static final DateTimeFormatter DATE_FORMAT =
+        DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z").withZone(ZoneOffset.UTC);
+
+    /**
+     * Parse all log lines from a {@link Reader} into a list of {@link Claim} objects.
+     */
+    public List<Claim> parse(Reader reader) throws IOException {
+        List<Claim> claims = new ArrayList<>();
+        try (BufferedReader br = new BufferedReader(reader)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                Claim c = parseLine(line);
+                if (c != null) {
+                    claims.add(c);
+                }
+            }
+        }
+        return claims;
+    }
+
+    /**
+     * Parse a single log line into a {@link Claim}. Returns {@code null} if the
+     * line does not match the expected format or contains invalid data.
+     */
+    public Claim parseLine(String line) {
+        Matcher m = LOG_PATTERN.matcher(line);
+        if (!m.find()) {
+            return null;
+        }
+        String srcIp = m.group(1);
+        String timestampStr = m.group(2);
+        String statusStr = m.group(3);
+        String target = m.group(4);
+
+        if (!validIp(srcIp)) {
+            return null;
+        }
+        String targetIp = target != null ? stripPort(target) : null;
+        if (targetIp != null && !validIp(targetIp)) {
+            return null;
+        }
+        Instant ts;
+        try {
+            ts = Instant.from(DATE_FORMAT.parse(timestampStr));
+        } catch (Exception e) {
+            return null;
+        }
+
+        Claim claim = new Claim();
+        claim.setTimestamp(ts);
+        claim.setSourceIp(srcIp);
+        claim.setTargetIp(targetIp);
+        int status = Integer.parseInt(statusStr);
+        claim.setConfidence(status >= 200 && status < 400 ? 1.0 : 0.5);
+        return claim;
+    }
+
+    private String stripPort(String ip) {
+        int idx = ip.indexOf(':');
+        return idx >= 0 ? ip.substring(0, idx) : ip;
+    }
+
+    private boolean validIp(String ip) {
+        return ip.matches("^((25[0-5]|2[0-4]\\d|[01]?\\d\\d?)(\\.(?!$)|$)){4}$");
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/test/java/com/enterprise/dependency/adapter/RouterLogAdapterTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/enterprise/dependency/adapter/RouterLogAdapterTest.java
@@ -1,0 +1,41 @@
+package com.enterprise.dependency.adapter;
+
+import java.io.StringReader;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RouterLogAdapterTest {
+
+    @Test
+    void parseValidLine() {
+        String line = "10.0.0.1 - - [01/Jan/2024:12:00:00 +0000] \"GET /index.html HTTP/1.1\" 200 123 192.168.1.10:80";
+        RouterLogAdapter adapter = new RouterLogAdapter();
+        Claim claim = adapter.parseLine(line);
+        assertNotNull(claim);
+        assertEquals("10.0.0.1", claim.getSourceIp());
+        assertEquals("192.168.1.10", claim.getTargetIp());
+        assertEquals(1.0, claim.getConfidence(), 0.001);
+    }
+
+    @Test
+    void parseInvalidIp() {
+        String line = "badip - - [01/Jan/2024:12:00:00 +0000] \"GET /index.html HTTP/1.1\" 200 123 192.168.1.10:80";
+        RouterLogAdapter adapter = new RouterLogAdapter();
+        assertNull(adapter.parseLine(line));
+    }
+
+    @Test
+    void parseMultipleLines() throws Exception {
+        String logs = String.join("\n",
+            "10.0.0.1 - - [01/Jan/2024:12:00:00 +0000] \"GET / HTTP/1.1\" 200 123 192.168.1.10:80",
+            "10.0.0.2 - - [01/Jan/2024:12:00:01 +0000] \"GET /foo HTTP/1.1\" 500 99 192.168.1.11:80"
+        );
+        RouterLogAdapter adapter = new RouterLogAdapter();
+        List<Claim> claims = adapter.parse(new StringReader(logs));
+        assertEquals(2, claims.size());
+        assertEquals(1.0, claims.get(0).getConfidence(), 0.001);
+        assertEquals(0.5, claims.get(1).getConfidence(), 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- implement RouterLogAdapter and Claim data model
- support parsing of Nginx/Apache style log lines
- provide IP validation and confidence scoring
- add unit tests verifying the parser

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68685dc819f08322840f272dd6b90a41