### PR TITLE
Add node-fetch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@expo/samples": "2.1.1",
         "expo": "^53.0.17",
         "metro": "^0.82.4",
+        "node-fetch": "^2.7.0",
         "react": "16.5.0",
         "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
         "react-navigation": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@expo/samples": "2.1.1",
     "expo": "^53.0.17",
     "metro": "^0.82.4",
+    "node-fetch": "^2.7.0",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
     "react-navigation": "^5.0.0"


### PR DESCRIPTION
## Summary
- ensure node-fetch is installed when using ApiGatewayAdapter

## Testing
- `npm test` *(fails: require.requireActual is not a function)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685dce37dc83228ec1f0cb711a0e3c