### PR TITLE
Refine conflict resolution with telemetry support

### DIFF
--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/TelemetryIngestionService.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/TelemetryIngestionService.java
@@ -1,0 +1,99 @@
+package com.example.mapper.service;
+
+import com.enterprise.dependency.model.core.Application;
+import com.enterprise.dependency.model.core.Claim;
+import com.example.mapper.repo.ApplicationRepository;
+import com.example.mapper.repo.ClaimRepository;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Ingests telemetry CSV files formatted as
+ * {@code timestamp,sourceService,targetService,count}. Lines not matching
+ * the expected format are ignored. Confidence is derived from the count and
+ * capped between 0.7 and 1.0.
+ */
+@Service
+public class TelemetryIngestionService {
+    private static final Logger log = LoggerFactory.getLogger(TelemetryIngestionService.class);
+    private static final Pattern LINE = Pattern.compile("^(\\S+),(\\S+),(\\S+),(\\d+)$");
+
+    private final ApplicationRepository appRepo;
+    private final ClaimRepository claimRepo;
+
+    public TelemetryIngestionService(ApplicationRepository appRepo, ClaimRepository claimRepo) {
+        this.appRepo = appRepo;
+        this.claimRepo = claimRepo;
+    }
+
+    /**
+     * Parse a telemetry CSV file and persist dependency claims.
+     *
+     * @param path path to the telemetry file
+     */
+    @Transactional
+    public void ingestTelemetry(String path) throws IOException {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(path))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                Claim claim = parseLine(line);
+                if (claim == null) {
+                    log.warn("Skipping malformed telemetry line: {}", line);
+                    continue;
+                }
+                claimRepo.save(claim);
+            }
+        }
+    }
+
+    private Claim parseLine(String line) {
+        Matcher m = LINE.matcher(line.trim());
+        if (!m.matches()) {
+            return null;
+        }
+        Instant ts;
+        try {
+            ts = Instant.parse(m.group(1));
+        } catch (Exception e) {
+            return null;
+        }
+        String from = m.group(2);
+        String to = m.group(3);
+        int count = Integer.parseInt(m.group(4));
+
+        if (from.isEmpty() || to.isEmpty()) {
+            return null;
+        }
+
+        Application fromApp = appRepo.findByName(from);
+        if (fromApp == null) {
+            fromApp = new Application();
+            fromApp.setName(from);
+            fromApp = appRepo.save(fromApp);
+        }
+        Application toApp = appRepo.findByName(to);
+        if (toApp == null) {
+            toApp = new Application();
+            toApp.setName(to);
+            toApp = appRepo.save(toApp);
+        }
+
+        Claim claim = new Claim();
+        claim.setFromApplication(fromApp);
+        claim.setToApplication(toApp);
+        claim.setSource("telemetry");
+        double confidence = 0.7 + Math.min(count, 50) / 200.0; // cap at 0.95
+        claim.setConfidence(Math.min(1.0, confidence));
+        claim.setTimestamp(ts);
+        return claim;
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/main/resources/application.properties
+++ b/dependency-mapper/dependency-mapper/src/main/resources/application.properties
@@ -8,4 +8,6 @@ spring.jpa.hibernate.ddl-auto=update
 snapshot.dir=snapshots
 source.priorities.manual=10
 source.priorities.auto=1
+recency.weight=1.0
+frequency.weight=1.0
 ingestion.adapters=routerLog,codebase,cicd,apiGateway,telemetry,networkLog

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/GraphSnapshotMutationTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/GraphSnapshotMutationTest.java
@@ -1,6 +1,6 @@
 package com.example.mapper;
 
-import com.example.mapper.model.DependencyClaim;
+import com.enterprise.dependency.model.core.Claim;
 import com.example.mapper.service.DependencyResolver;
 import com.example.mapper.service.GraphSnapshotService;
 import java.io.IOException;
@@ -15,24 +15,24 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GraphSnapshotMutationTest {
 
     private static class StubResolver extends DependencyResolver {
-        private final Map<String, Map<String, DependencyClaim>> graph;
+        private final Map<String, Map<String, Claim>> graph;
 
-        StubResolver(Map<String, Map<String, DependencyClaim>> graph) {
+        StubResolver(Map<String, Map<String, Claim>> graph) {
             super(null);
             this.graph = graph;
         }
 
         @Override
-        public Map<String, Map<String, DependencyClaim>> resolve() {
+        public Map<String, Map<String, Claim>> resolve() {
             return graph;
         }
     }
 
     @Test
     void exportDoesNotMutateGraph() throws IOException {
-        Map<String, Map<String, DependencyClaim>> graph = new HashMap<>();
-        Map<String, DependencyClaim> edges = new HashMap<>();
-        edges.put("B", new DependencyClaim());
+        Map<String, Map<String, Claim>> graph = new HashMap<>();
+        Map<String, Claim> edges = new HashMap<>();
+        edges.put("B", new Claim());
         graph.put("A", edges);
 
         StubResolver resolver = new StubResolver(graph);

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/TelemetryIngestionServiceTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/TelemetryIngestionServiceTest.java
@@ -1,0 +1,34 @@
+package com.example.mapper;
+
+import com.example.mapper.service.TelemetryIngestionService;
+import com.example.mapper.service.WeightedConflictResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class TelemetryIngestionServiceTest {
+
+    @Autowired
+    private TelemetryIngestionService ingestionService;
+
+    @Autowired
+    private WeightedConflictResolver resolver;
+
+    @Test
+    void ingestTelemetryFile() throws IOException {
+        Path temp = Files.createTempFile("telemetry", ".csv");
+        try (FileWriter w = new FileWriter(temp.toFile())) {
+            w.write("2024-07-04T10:30:45Z,ServiceA,ServiceB,30\n");
+            w.write("2024-07-04T10:31:45Z,ServiceA,ServiceB,20\n");
+            w.write("bad,line\n");
+        }
+        ingestionService.ingestTelemetry(temp.toString());
+        assertEquals(1, resolver.toList().size());
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/WeightedConflictResolverTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/WeightedConflictResolverTest.java
@@ -17,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = {
         "source.priorities.manual=5",
         "source.priorities.auto=1",
-        "overrides.ServiceA->ServiceC=manual"
+        "overrides.ServiceA->ServiceC=manual",
+        "recency.weight=1",
+        "frequency.weight=1"
 })
 public class WeightedConflictResolverTest {
 
@@ -81,24 +83,24 @@ public class WeightedConflictResolverTest {
 
     @Test
     void testRecencyBias() {
-        ApplicationService x = new ApplicationService();
+        Application x = new Application();
         x.setName("ServiceX");
-        x = serviceRepo.save(x);
-        ApplicationService y = new ApplicationService();
+        x = appRepo.save(x);
+        Application y = new Application();
         y.setName("ServiceY");
-        y = serviceRepo.save(y);
+        y = appRepo.save(y);
 
-        DependencyClaim oldC = new DependencyClaim();
-        oldC.setFromService(x);
-        oldC.setToService(y);
+        Claim oldC = new Claim();
+        oldC.setFromApplication(x);
+        oldC.setToApplication(y);
         oldC.setSource("auto");
         oldC.setConfidence(0.5);
         oldC.setTimestamp(Instant.now().minusSeconds(7200));
         claimRepo.save(oldC);
 
-        DependencyClaim newC = new DependencyClaim();
-        newC.setFromService(x);
-        newC.setToService(y);
+        Claim newC = new Claim();
+        newC.setFromApplication(x);
+        newC.setToApplication(y);
         newC.setSource("auto");
         newC.setConfidence(0.5);
         newC.setTimestamp(Instant.now());


### PR DESCRIPTION
## Summary
- weight frequency & recency in `WeightedConflictResolver`
- add `TelemetryIngestionService` for CSV metrics
- expose new weight properties
- update tests and fix outdated classes

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_6868688df9dc8322beec59bfd92fafe9