### PR TITLE
Implement claim processing engine

### DIFF
--- a/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/ApiGatewayCall.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/ApiGatewayCall.java
@@ -1,0 +1,17 @@
+package com.enterprise.dependency.model.sources;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Describes a call recorded by an API gateway.
+ */
+@Data
+public class ApiGatewayCall {
+    private Instant timestamp;
+    private String sourceService;
+    private String targetService;
+    private String endpoint;
+    private String method;
+    private long responseTimeMs;
+}

--- a/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/CodebaseDependency.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/CodebaseDependency.java
@@ -1,0 +1,13 @@
+package com.enterprise.dependency.model.sources;
+
+import lombok.Data;
+
+/**
+ * Represents a dependency discovered in the codebase.
+ */
+@Data
+public class CodebaseDependency {
+    private String groupId;
+    private String artifactId;
+    private String version;
+}

--- a/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/RouterLogEntry.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/enterprise/dependency/model/sources/RouterLogEntry.java
@@ -1,0 +1,18 @@
+package com.enterprise.dependency.model.sources;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Represents a parsed router log line.
+ */
+@Data
+public class RouterLogEntry {
+    private Instant timestamp;
+    private String sourceIp;
+    private String targetIp;
+    private String method;
+    private String path;
+    private int status;
+    private long responseTimeMs;
+}

--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/ClaimProcessingEngine.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/ClaimProcessingEngine.java
@@ -1,0 +1,144 @@
+package com.example.mapper.service;
+
+import com.enterprise.dependency.model.core.Application;
+import com.enterprise.dependency.model.core.Claim;
+import com.enterprise.dependency.model.sources.ApiGatewayCall;
+import com.enterprise.dependency.model.sources.CodebaseDependency;
+import com.enterprise.dependency.model.sources.RouterLogEntry;
+import com.example.mapper.repo.ApplicationRepository;
+import com.example.mapper.repo.ClaimRepository;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Processes raw data models from various sources into {@link Claim} entities.
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * {@code
+ * RouterLogEntry entry = new RouterLogEntry();
+ * entry.setSourceIp("10.0.0.1");
+ * entry.setTargetIp("10.0.0.2");
+ * entry.setTimestamp(Instant.now());
+ * Claim claim = engine.processRouterLog(entry);
+ * }
+ * </pre>
+ */
+@Service
+public class ClaimProcessingEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(ClaimProcessingEngine.class);
+
+    private final ApplicationRepository appRepo;
+    private final ClaimRepository claimRepo;
+
+    @Value("${confidence.routerLog:0.9}")
+    private double routerLogConfidence;
+
+    @Value("${confidence.codebase:0.95}")
+    private double codebaseConfidence;
+
+    @Value("${confidence.apiGateway:0.85}")
+    private double apiGatewayConfidence;
+
+    public ClaimProcessingEngine(ApplicationRepository appRepo, ClaimRepository claimRepo) {
+        this.appRepo = appRepo;
+        this.claimRepo = claimRepo;
+    }
+
+    /**
+     * Convert a router log entry into a {@link Claim} and persist it.
+     *
+     * @param entry router log data
+     * @return persisted claim
+     */
+    @Transactional
+    public Claim processRouterLog(RouterLogEntry entry) {
+        long start = System.nanoTime();
+        validateRouterLog(entry);
+        Claim claim = buildClaim(entry.getSourceIp(), entry.getTargetIp(), "routerLog", routerLogConfidence, entry.getTimestamp());
+        claimRepo.save(claim);
+        log.info("Processed router log in {} ms", (System.nanoTime() - start) / 1_000_000);
+        return claim;
+    }
+
+    /**
+     * Convert a codebase dependency into a {@link Claim} and persist it.
+     *
+     * @param dep code dependency
+     * @return persisted claim
+     */
+    @Transactional
+    public Claim processCodebaseDependency(CodebaseDependency dep) {
+        long start = System.nanoTime();
+        validateCodebase(dep);
+        String from = dep.getGroupId();
+        String to = dep.getArtifactId();
+        Claim claim = buildClaim(from, to, "codebase", codebaseConfidence, Instant.now());
+        claimRepo.save(claim);
+        log.info("Processed codebase dep in {} ms", (System.nanoTime() - start) / 1_000_000);
+        return claim;
+    }
+
+    /**
+     * Convert an API gateway call into a {@link Claim} and persist it.
+     *
+     * @param call gateway call
+     * @return persisted claim
+     */
+    @Transactional
+    public Claim processApiGatewayCall(ApiGatewayCall call) {
+        long start = System.nanoTime();
+        validateGateway(call);
+        Claim claim = buildClaim(call.getSourceService(), call.getTargetService(), "apiGateway", apiGatewayConfidence, call.getTimestamp());
+        claimRepo.save(claim);
+        log.info("Processed gateway call in {} ms", (System.nanoTime() - start) / 1_000_000);
+        return claim;
+    }
+
+    private Claim buildClaim(String fromName, String toName, String source, double confidence, Instant ts) {
+        Application from = findOrCreate(fromName);
+        Application to = findOrCreate(toName);
+        Claim claim = new Claim();
+        claim.setFromApplication(from);
+        claim.setToApplication(to);
+        claim.setSource(source);
+        claim.setConfidence(confidence);
+        claim.setTimestamp(ts != null ? ts : Instant.now());
+        return claim;
+    }
+
+    private Application findOrCreate(String name) {
+        Application app = appRepo.findByName(name);
+        if (app == null) {
+            app = new Application();
+            app.setName(name);
+            app = appRepo.save(app);
+        }
+        return app;
+    }
+
+    private void validateRouterLog(RouterLogEntry entry) {
+        if (entry == null || entry.getSourceIp() == null || entry.getTargetIp() == null) {
+            throw new IllegalArgumentException("Invalid router log entry");
+        }
+        // TODO enhance validation using regex
+    }
+
+    private void validateCodebase(CodebaseDependency dep) {
+        if (dep == null || dep.getGroupId() == null || dep.getArtifactId() == null) {
+            throw new IllegalArgumentException("Invalid codebase dependency");
+        }
+    }
+
+    private void validateGateway(ApiGatewayCall call) {
+        if (call == null || call.getSourceService() == null || call.getTargetService() == null) {
+            throw new IllegalArgumentException("Invalid API gateway call");
+        }
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/main/resources/application.properties
+++ b/dependency-mapper/dependency-mapper/src/main/resources/application.properties
@@ -11,3 +11,6 @@ source.priorities.auto=1
 recency.weight=1.0
 frequency.weight=1.0
 ingestion.adapters=routerLog,codebase,cicd,apiGateway,telemetry,networkLog
+confidence.routerLog=0.9
+confidence.codebase=0.95
+confidence.apiGateway=0.85

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/ClaimProcessingEngineTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/ClaimProcessingEngineTest.java
@@ -1,0 +1,59 @@
+package com.example.mapper;
+
+import com.enterprise.dependency.model.sources.ApiGatewayCall;
+import com.enterprise.dependency.model.sources.CodebaseDependency;
+import com.enterprise.dependency.model.sources.RouterLogEntry;
+import com.example.mapper.repo.ApplicationRepository;
+import com.example.mapper.repo.ClaimRepository;
+import com.example.mapper.service.ClaimProcessingEngine;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ClaimProcessingEngineTest {
+
+    @Autowired
+    private ClaimProcessingEngine engine;
+    @Autowired
+    private ApplicationRepository appRepo;
+    @Autowired
+    private ClaimRepository claimRepo;
+
+    @Test
+    void processRouterLog() {
+        RouterLogEntry entry = new RouterLogEntry();
+        entry.setSourceIp("10.0.0.1");
+        entry.setTargetIp("10.0.0.2");
+        entry.setTimestamp(Instant.now());
+        var claim = engine.processRouterLog(entry);
+        assertNotNull(claim.getId());
+        assertEquals(0.9, claim.getConfidence(), 0.0001);
+    }
+
+    @Test
+    void processCodebaseDependency() {
+        CodebaseDependency dep = new CodebaseDependency();
+        dep.setGroupId("group");
+        dep.setArtifactId("artifact");
+        dep.setVersion("1.0");
+        var claim = engine.processCodebaseDependency(dep);
+        assertNotNull(claim.getId());
+        assertEquals(0.95, claim.getConfidence(), 0.0001);
+    }
+
+    @Test
+    void processApiGatewayCall() {
+        ApiGatewayCall call = new ApiGatewayCall();
+        call.setSourceService("svcA");
+        call.setTargetService("svcB");
+        call.setTimestamp(Instant.now());
+        var claim = engine.processApiGatewayCall(call);
+        assertNotNull(claim.getId());
+        assertEquals(0.85, claim.getConfidence(), 0.0001);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce source models for router logs, codebase dependencies and API gateway calls
- add `ClaimProcessingEngine` to normalize data and compute confidence scores
- configure default confidence values
- create unit tests for claim processing

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68686ea2e60483228e7147914631e57d