### PR TITLE
Implement transitive inference service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,8 @@ These scripts capture commit metadata such as hash, author, date, and message. E
 
 ### Fri Jul 4 13:15:37 2025 +0000
 - Implement Bayesian conflict resolution (0cadcf89c3851787b7242d31719e2fed57139d1a)
+
+commit c5889700ae77b06c0a0617e7359687b941701c2d
+Author: Codex
+Date:   Sun Jul 6 08:10:31 2025 +0000
+Message: Add transitive inference service

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -58,3 +58,8 @@ Author: Codex
 Date:   Fri Jul 4 13:15:37 2025 +0000
 Message: Implement Bayesian conflict resolution
 
+
+commit c5889700ae77b06c0a0617e7359687b941701c2d
+Author: Codex
+Date:   Sun Jul 6 08:10:31 2025 +0000
+Message: Add transitive inference service

--- a/dependency-mapper/dependency-mapper/pom.xml
+++ b/dependency-mapper/dependency-mapper/pom.xml
@@ -57,6 +57,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.7.18</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/TransitiveInferenceService.java
+++ b/dependency-mapper/dependency-mapper/src/main/java/com/example/mapper/service/TransitiveInferenceService.java
@@ -1,0 +1,61 @@
+package com.example.mapper.service;
+
+import com.enterprise.dependency.model.core.Claim;
+import java.util.*;
+import org.springframework.stereotype.Service;
+
+/**
+ * Infers transitive dependencies from the resolved dependency graph.
+ * If ServiceA depends on ServiceB and ServiceB depends on ServiceC,
+ * this service will infer ServiceA -> ServiceC.
+ */
+@Service
+public class TransitiveInferenceService {
+    private final WeightedConflictResolver resolver;
+
+    public TransitiveInferenceService(WeightedConflictResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    /**
+     * Returns a map of each application to all applications it depends on
+     * directly or transitively.
+     */
+    public Map<String, Set<String>> inferTransitive() {
+        Map<String, Map<String, Claim>> graph = resolver.resolve();
+        Map<String, Set<String>> result = new HashMap<>();
+        for (String start : graph.keySet()) {
+            Set<String> visited = new LinkedHashSet<>();
+            Deque<String> queue = new ArrayDeque<>();
+            queue.add(start);
+            while (!queue.isEmpty()) {
+                String current = queue.poll();
+                Map<String, Claim> edges = graph.get(current);
+                if (edges == null) continue;
+                for (String next : edges.keySet()) {
+                    if (visited.add(next)) {
+                        queue.add(next);
+                    }
+                }
+            }
+            visited.remove(start);
+            result.put(start, visited);
+        }
+        return result;
+    }
+
+    /**
+     * Convenience method returning dependencies as list of "A->B" strings.
+     */
+    public List<String> toList() {
+        Map<String, Set<String>> map = inferTransitive();
+        List<String> list = new ArrayList<>();
+        for (var e : map.entrySet()) {
+            String from = e.getKey();
+            for (String to : e.getValue()) {
+                list.add(from + "->" + to);
+            }
+        }
+        return list;
+    }
+}

--- a/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/TransitiveInferenceServiceTest.java
+++ b/dependency-mapper/dependency-mapper/src/test/java/com/example/mapper/TransitiveInferenceServiceTest.java
@@ -1,0 +1,45 @@
+package com.example.mapper;
+
+import com.enterprise.dependency.model.core.Claim;
+import com.example.mapper.service.TransitiveInferenceService;
+import com.example.mapper.service.WeightedConflictResolver;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransitiveInferenceServiceTest {
+
+    private static class StubResolver extends WeightedConflictResolver {
+        private final Map<String, Map<String, Claim>> graph;
+        StubResolver(Map<String, Map<String, Claim>> graph) {
+            super(null, Map.of(), Map.of(), 1.0, 1.0);
+            this.graph = graph;
+        }
+        @Override
+        public Map<String, Map<String, Claim>> resolve() {
+            return graph;
+        }
+    }
+
+    @Test
+    void infersTransitiveEdges() {
+        Map<String, Map<String, Claim>> g = new HashMap<>();
+        g.put("A", new HashMap<>());
+        g.put("B", new HashMap<>());
+        g.get("A").put("B", new Claim());
+        g.get("B").put("C", new Claim());
+
+        StubResolver resolver = new StubResolver(g);
+        TransitiveInferenceService service = new TransitiveInferenceService(resolver);
+        Map<String, Set<String>> map = service.inferTransitive();
+
+        assertTrue(map.get("A").contains("B"));
+        assertTrue(map.get("A").contains("C"), "A should depend transitively on C");
+        assertTrue(map.get("B").contains("C"));
+        List<String> list = service.toList();
+        assertTrue(list.contains("A->C"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TransitiveInferenceService` to derive indirect edges
- add unit test for new inference service
- patch pom.xml with plugin version
- update release log and README

## Testing
- `mvn test` *(fails: Plugin not found due to network restrictions)*
- `npm test` *(fails: missing jest module)*

------
https://chatgpt.com/codex/tasks/task_e_686a2cfbaaec8322b5d9b102b497164f